### PR TITLE
fix: Remove box-shadow from category cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
                 padding-bottom: 0.45rem;
                 -ms-overflow-style: none;
                 scrollbar-width: none;
-                background: none;
+                background-color: white !important;
             }
             .categories.container::-webkit-scrollbar {
                 display: none;
@@ -1221,6 +1221,8 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
                 height: 120px;
                 padding-top: 1.5rem;
                 padding-bottom: 0.5;
+                background-color: white !important;
+                box-shadow: none;
             }
             .footer-brand-info { display: none !important; }
             .footer-content { grid-template-columns: 1fr; gap: 1.8rem; }


### PR DESCRIPTION
Removes the `box-shadow` from the `.category` elements in the mobile media query. The shadow may have been rendering as a solid black background on some mobile devices.